### PR TITLE
Avoid id conflict

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -4,6 +4,7 @@ const mapTodos = (state, id, prop) => ({
   )
 })
 
+let counter = 0
 
 export default {
   add: state => ({
@@ -12,7 +13,7 @@ export default {
       completed: false,
       editing: false,
       value: state.input,
-      id: state.todos.length + 1
+      id: ++counter
     })
   }),
 


### PR DESCRIPTION
To reproduce bug:
- add items A and B.
- remove A
- add item C
- try to remove B: C is also deleted because B and C have the same id.

as discussed here:  https://github.com/hyperapp/hyperapp/issues/221#issuecomment-312520199